### PR TITLE
Clean up PCA plots

### DIFF
--- a/inst/shiny/PathoStat/server/server_05_dimreduction.R
+++ b/inst/shiny/PathoStat/server/server_05_dimreduction.R
@@ -1,186 +1,174 @@
-
-
-  # independent heatmap plotting function in the server using specific data from input
-  plotPCAPlotlyServer <- function(){
-      shinyInput <- vals$shiny.input
-    physeq1 <- shinyInput$pstat
-    if (input$taxl.pca=="no rank")  {
-      df.plot <- physeq1@otu_table@.Data
-      if (input$select_pca_data_format == "log10 CPM"){
-        df.plot <- getLogCPM(df.plot)
-      }else if (input$select_pca_data_format == "RA"){
-        df.plot <- getRelativeAbundance(df.plot)
-      }
-      plotPCAPlotly(df.input = df.plot,
-                    condition.color.vec = physeq1@sam_data[[input$select_pca_color]],
-                    condition.color.name = input$select_pca_color,
-                    condition.shape.vec = physeq1@sam_data[[input$select_pca_shape]],
-                    condition.shape.name = input$select_pca_shape,
-
-                    pc.a = paste("PC", input$xcol.new, sep = ""),
-                    pc.b = paste("PC", input$ycol.new, sep = ""),
-                    columnTitle = paste("PCA with colorbar representing",
-                                        input$select_pca_color, sep = " "))
-    } else  {
-      physeq2 <- tax_glom(physeq1, input$taxl.pca)
-      df.plot <- physeq2@otu_table@.Data
-      if (input$select_pca_data_format == "log10 CPM"){
-        df.plot <- getLogCPM(df.plot)
-      }else if (input$select_pca_data_format == "RA"){
-        df.plot <- getRelativeAbundance(df.plot)
-      }
-      plotPCAPlotly(df.input = df.plot,
-                    condition.color.vec = physeq2@sam_data[[input$select_pca_color]],
-                    condition.color.name = input$select_pca_color,
-                    condition.shape.vec = physeq1@sam_data[[input$select_pca_shape]],
-                    condition.shape.name = input$select_pca_shape,
-                    pc.a = paste("PC", input$xcol.new, sep = ""),
-                    pc.b = paste("PC", input$ycol.new, sep = ""),
-                    columnTitle = paste("PCA with colorbar representing",
-                                        input$select_pca_color, sep = " "))}
-  }
-
-  # show heatmap in the shiny app by calling the plotting function
-
-
-  plotPCAPlotlyServerButton <- eventReactive(input$DR_plot,{
-      plotPCAPlotlyServer()
-  })
-
-  output$pca.plotly <- renderPlotly({
-    plotPCAPlotlyServerButton()
-
-  })
-
-  # interactive PCA table
-  output$PCAtable <- DT::renderDataTable({
-      shinyInput <- vals$shiny.input
-    physeq1 <- shinyInput$pstat
-    if (input$taxl.pca=="no rank")  {
-      #test and fix the constant/zero row
-      if (sum(rowSums(as.matrix(physeq1@otu_table@.Data)) == 0) > 0){
-        physeq1@otu_table@.Data <- data.frame(physeq1@otu_table@.Data[-which
-                                                                      (rowSums(as.matrix(physeq1@otu_table@.Data)) == 0),])
-      }
-      pca.tmp <- prcomp(t(physeq1@otu_table@.Data), scale = TRUE)
-
-    } else  {
-      physeq2 <- tax_glom(physeq1, input$taxl.pca)
-      if (sum(rowSums(as.matrix(physeq2@otu_table@.Data)) == 0) > 0){
-        physeq2@otu_table@.Data <- data.frame(physeq2@otu_table@.Data[-which
-                                                                      (rowSums(as.matrix(physeq2@otu_table@.Data)) == 0),])
-      }
-      pca.tmp <- prcomp(t(physeq2@otu_table@.Data), scale = TRUE)
-
+# independent heatmap plotting function in the server using specific data from input
+plotPCAPlotlyServer <- function(){
+  shinyInput <- vals$shiny.input
+  physeq1 <- shinyInput$pstat
+  if (input$taxl.pca=="no rank")  {
+    df.plot <- physeq1@otu_table@.Data
+    if (input$select_pca_data_format == "log10 CPM"){
+      df.plot <- getLogCPM(df.plot)
+    } else if (input$select_pca_data_format == "RA"){
+      df.plot <- getRelativeAbundance(df.plot)
     }
-
-    table.output.pca <- t(summary(pca.tmp)$importance)
-    table.output.pca[,2] <- scales::percent(as.numeric(table.output.pca[,2]))
-    table.output.pca[,3] <- scales::percent(as.numeric(table.output.pca[,3]))
-    #hide std
-    DT::datatable(table.output.pca[,-1])
-
-  })
-
-  ### PCoA
-  plotPCoAPlotlyServer <- function(){
-      shinyInput <- vals$shiny.input
-    physeq1 <- shinyInput$pstat
-    physeq1 <- phyloseq(otu_table(physeq1), phy_tree(physeq1),
-                        tax_table(physeq1), sample_data(physeq1))
-    if (input$taxl.pca=="no rank")  {
-      plotPCoAPlotly(physeq.input = physeq1,
-                     condition.color.vec = physeq1@sam_data[[input$select_pca_color]],
-                     condition.color.name = input$select_pca_color,
-                     condition.shape.vec = physeq1@sam_data[[input$select_pca_shape]],
-                     condition.shape.name = input$select_pca_shape,
-                     method = input$pcoa.method,
-                     pc.a = paste("Axis", input$xcol.new, sep = "."),
-                     pc.b = paste("Axis", input$ycol.new, sep = "."),
-                     columnTitle = paste("PCoA with colorbar representing",
-                                         input$select_pca_color, sep = " "))
-    } else  {
-      physeq2 <- tax_glom(physeq1, input$taxl.pca)
-      plotPCoAPlotly(physeq.input = physeq2,
-                     condition.color.vec = physeq2@sam_data[[input$select_pca_color]],
-                     condition.color.name = input$select_pca_color,
-                     condition.shape.vec = physeq1@sam_data[[input$select_pca_shape]],
-                     condition.shape.name = input$select_pca_shape,
-                     method = input$pcoa.method,
-                     pc.a = paste("Axis", input$xcol.new, sep = "."),
-                     pc.b = paste("Axis", input$ycol.new, sep = "."),
-                     columnTitle = paste("PCoA with colorbar representing",
-                                         input$select_pca_color, sep = " "))}
-  }
-
-
-
-  plotPCoAPlotlyServerButton <- eventReactive(input$DR_plot,{
-      plotPCoAPlotlyServer()
-  })
-
-  output$pcoa.plotly <- renderPlotly({
-    plotPCoAPlotlyServerButton()
-
-  })
-
-
-  getOrdPCoA <- function(){
-      shinyInput <- vals$shiny.input
-    physeq1 <- shinyInput$pstat
-    if (input$taxl.pca=="no rank")  {
-      #test and fix the constant/zero row
-      if (sum(rowSums(as.matrix(physeq1@otu_table@.Data)) == 0) > 0){
-        physeq1@otu_table@.Data <- data.frame(physeq1@otu_table@.Data[-which
-                                                                      (rowSums(as.matrix(physeq1@otu_table@.Data)) == 0),])
-      }
-      if (input$select_beta_div_method == "bray"){
-        #First get otu_table and transpose it:
-        dist.matrix <- t(data.frame(otu_table(physeq1)))
-        #Then use vegdist from vegan to generate a bray distance object:
-        DistBC <- vegdist(dist.matrix, method = "bray")
-        ord.tmp <- ordinate(physeq1, method = "PCoA", distance = DistBC)
-      } else{
-        Dist.tmp <- phyloseq::distance(physeq1, method = input$select_beta_div_method)
-        ord.tmp <- ordinate(physeq1, method = "PCoA", distance = Dist.tmp)
-      }
-
-      #cat(dim(physeq1@otu_table))
-      return(ord.tmp$values)
-
-    } else  {
-      physeq2 <- tax_glom(physeq1, input$taxl.pca)
-      if (sum(rowSums(as.matrix(physeq2@otu_table@.Data)) == 0) > 0){
-        physeq2@otu_table@.Data <- data.frame(physeq2@otu_table@.Data[-which
-                                                                      (rowSums(as.matrix(physeq2@otu_table@.Data)) == 0),])
-      }
-      if (input$select_beta_div_method == "bray"){
-        #First get otu_table and transpose it:
-        dist.matrix <- t(data.frame(otu_table(physeq2)))
-        #Then use vegdist from vegan to generate a bray distance object:
-        DistBC <- vegdist(dist.matrix, method = "bray")
-        ord.tmp <- ordinate(physeq2, method = "PCoA", distance = DistBC)
-      } else{
-        Dist.tmp <- phyloseq::distance(physeq2, method = input$select_beta_div_method)
-        ord.tmp <- ordinate(physeq2, method = "PCoA", distance = Dist.tmp)
-      }
-      return(ord.tmp$values)
-
+    plotPCAPlotly(df.input = df.plot,
+                  condition.color.vec = physeq1@sam_data[[input$select_pca_color]],
+                  condition.color.name = input$select_pca_color,
+                  condition.shape.vec = physeq1@sam_data[[input$select_pca_shape]],
+                  condition.shape.name = input$select_pca_shape,
+                  pc.a = paste("PC", input$xcol.new, sep = ""),
+                  pc.b = paste("PC", input$ycol.new, sep = ""),
+                  columnTitle = paste("PCA with colorbar representing", 
+                                       input$select_pca_color, sep = " ")
+    )
+  } else  {
+    physeq2 <- tax_glom(physeq1, input$taxl.pca)
+    df.plot <- physeq2@otu_table@.Data
+    if (input$select_pca_data_format == "log10 CPM") {
+      df.plot <- getLogCPM(df.plot)
+    } else if (input$select_pca_data_format == "RA"){
+      df.plot <- getRelativeAbundance(df.plot)
     }
+    plotPCAPlotly(df.input = df.plot,
+                  condition.color.vec = physeq2@sam_data[[input$select_pca_color]],
+                  condition.color.name = input$select_pca_color,
+                  condition.shape.vec = physeq1@sam_data[[input$select_pca_shape]],
+                  condition.shape.name = input$select_pca_shape,
+                  pc.a = paste("PC", input$xcol.new, sep = ""),
+                  pc.b = paste("PC", input$ycol.new, sep = ""),
+                  columnTitle = paste("PCA with colorbar representing",
+                                      input$select_pca_color, sep = " ")
+    )
   }
+}
 
+# show heatmap in the shiny app by calling the plotting function
+plotPCAPlotlyServerButton <- eventReactive(input$DR_plot,{
+  plotPCAPlotlyServer()
+})
 
-  # interactive PCA table
-  output$PCoAtable <- DT::renderDataTable({
-      shinyInput <- vals$shiny.input
-    physeq1 <- shinyInput$pstat
-    ord <- getOrdPCoA()
-    df.output <- ord[,c(1,3,5)]
-    colnames(df.output) <- c("eigenvalue", "variance explained", "cumulative variance")
-    rownames(df.output) <- paste("Axis", 1:nrow(df.output), sep = ".")
-    df.output[,2] <- scales::percent(as.numeric(df.output[,2]))
-    df.output[,3] <- scales::percent(as.numeric(df.output[,3]))
-    # hide eigenvalue
-    DT::datatable(df.output[,-1])
+output$pca.plotly <- renderPlotly({
+  plotPCAPlotlyServerButton()
+})
 
-  })
+# interactive PCA table
+output$PCAtable <- DT::renderDataTable({
+  shinyInput <- vals$shiny.input
+  physeq1 <- shinyInput$pstat
+  if (input$taxl.pca=="no rank")  {
+    #test and fix the constant/zero row
+    if (sum(rowSums(as.matrix(physeq1@otu_table@.Data)) == 0) > 0){
+      physeq1@otu_table@.Data <- data.frame(physeq1@otu_table@.Data[-which
+                                           (rowSums(as.matrix(physeq1@otu_table@.Data)) == 0),])
+    }
+    pca.tmp <- prcomp(t(physeq1@otu_table@.Data), scale = TRUE)
+  } else  {
+    physeq2 <- tax_glom(physeq1, input$taxl.pca)
+    if (sum(rowSums(as.matrix(physeq2@otu_table@.Data)) == 0) > 0){
+      physeq2@otu_table@.Data <- data.frame(physeq2@otu_table@.Data[-which
+                                           (rowSums(as.matrix(physeq2@otu_table@.Data)) == 0),])
+    }
+    pca.tmp <- prcomp(t(physeq2@otu_table@.Data), scale = TRUE)
+  }
+  table.output.pca <- t(summary(pca.tmp)$importance)
+  colnames(table.output.pca) = c("Standard deviation", "Variance Explained", "Cumulative Variance")
+  table.output.pca[,2] <- scales::percent(as.numeric(table.output.pca[,2]))
+  table.output.pca[,3] <- scales::percent(as.numeric(table.output.pca[,3]))
+  #hide std
+  DT::datatable(table.output.pca[,-1], options = list(sDom  = '<"top">t<"bottom">ip'))
+})
+
+### PCoA
+plotPCoAPlotlyServer <- function(){
+  shinyInput <- vals$shiny.input
+  physeq1 <- shinyInput$pstat
+  physeq1 <- phyloseq(otu_table(physeq1), phy_tree(physeq1),
+                      tax_table(physeq1), sample_data(physeq1))
+  if (input$taxl.pca=="no rank")  {
+    plotPCoAPlotly(physeq.input = physeq1,
+                   condition.color.vec = physeq1@sam_data[[input$select_pca_color]],
+                   condition.color.name = input$select_pca_color,
+                   condition.shape.vec = physeq1@sam_data[[input$select_pca_shape]],
+                   condition.shape.name = input$select_pca_shape,
+                   method = input$pcoa.method,
+                   pc.a = paste("Axis", input$xcol.new, sep = "."),
+                   pc.b = paste("Axis", input$ycol.new, sep = "."),
+                   columnTitle = paste("PCoA with colorbar representing",
+                                       input$select_pca_color, sep = " ")
+    )
+  } else  {
+    physeq2 <- tax_glom(physeq1, input$taxl.pca)
+    plotPCoAPlotly(physeq.input = physeq2,
+                   condition.color.vec = physeq2@sam_data[[input$select_pca_color]],
+                   condition.color.name = input$select_pca_color,
+                   condition.shape.vec = physeq1@sam_data[[input$select_pca_shape]],
+                   condition.shape.name = input$select_pca_shape,
+                   method = input$pcoa.method,
+                   pc.a = paste("Axis", input$xcol.new, sep = "."),
+                   pc.b = paste("Axis", input$ycol.new, sep = "."),
+                   columnTitle = paste("PCoA with colorbar representing",
+                                       input$select_pca_color, sep = " ")
+    )
+  }
+}
+
+plotPCoAPlotlyServerButton <- eventReactive(input$DR_plot,{
+  plotPCoAPlotlyServer()
+})
+
+output$pcoa.plotly <- renderPlotly({
+  plotPCoAPlotlyServerButton()
+})
+
+getOrdPCoA <- function(){
+  shinyInput <- vals$shiny.input
+  physeq1 <- shinyInput$pstat
+  if (input$taxl.pca=="no rank")  {
+    #test and fix the constant/zero row
+    if (sum(rowSums(as.matrix(physeq1@otu_table@.Data)) == 0) > 0){
+      physeq1@otu_table@.Data <- data.frame(physeq1@otu_table@.Data[-which
+                                           (rowSums(as.matrix(physeq1@otu_table@.Data)) == 0),])
+    }
+    if (input$select_beta_div_method == "bray"){
+      #First get otu_table and transpose it:
+      dist.matrix <- t(data.frame(otu_table(physeq1)))
+      #Then use vegdist from vegan to generate a bray distance object:
+      DistBC <- vegdist(dist.matrix, method = "bray")
+      ord.tmp <- ordinate(physeq1, method = "PCoA", distance = DistBC)
+    } else{
+      Dist.tmp <- phyloseq::distance(physeq1, method = input$select_beta_div_method)
+      ord.tmp <- ordinate(physeq1, method = "PCoA", distance = Dist.tmp)
+    }
+    #cat(dim(physeq1@otu_table))
+    return(ord.tmp$values)
+  } else  {
+    physeq2 <- tax_glom(physeq1, input$taxl.pca)
+    if (sum(rowSums(as.matrix(physeq2@otu_table@.Data)) == 0) > 0){
+      physeq2@otu_table@.Data <- data.frame(physeq2@otu_table@.Data[-which
+                                           (rowSums(as.matrix(physeq2@otu_table@.Data)) == 0),])
+    }
+    if (input$select_beta_div_method == "bray"){
+      #First get otu_table and transpose it:
+      dist.matrix <- t(data.frame(otu_table(physeq2)))
+      #Then use vegdist from vegan to generate a bray distance object:
+      DistBC <- vegdist(dist.matrix, method = "bray")
+      ord.tmp <- ordinate(physeq2, method = "PCoA", distance = DistBC)
+    } else{
+      Dist.tmp <- phyloseq::distance(physeq2, method = input$select_beta_div_method)
+      ord.tmp <- ordinate(physeq2, method = "PCoA", distance = Dist.tmp)
+    }
+    return(ord.tmp$values)
+  }
+}
+
+# interactive PCA table
+output$PCoAtable <- DT::renderDataTable({
+  shinyInput <- vals$shiny.input
+  physeq1 <- shinyInput$pstat
+  ord <- getOrdPCoA()
+  df.output <- ord[,c(1,3,5)]
+  colnames(df.output) <- c("eigenvalue", "Variance Explained", "Cumulative Variance")
+  rownames(df.output) <- paste("Axis", 1:nrow(df.output), sep = ".")
+  df.output[,2] <- scales::percent(as.numeric(df.output[,2]))
+  df.output[,3] <- scales::percent(as.numeric(df.output[,3]))
+  # hide eigenvalue
+  DT::datatable(df.output[,-1], options = list(sDom  = '<"top">t<"bottom">ip'))
+})

--- a/inst/shiny/PathoStat/ui/ui_05_dimreduction.R
+++ b/inst/shiny/PathoStat/ui/ui_05_dimreduction.R
@@ -1,32 +1,39 @@
-
 tabPanel("Dimension Reduction",
-         sidebarLayout(
-             sidebarPanel(
-                 numericInput('xcol.new', 'Principal Component (x-axis)', 1,
-                              min = 1, max = 50),
-                 numericInput('ycol.new', 'Principal Component (y-axis)', 2,
-                              min = 1, max = 50),
-                 selectizeInput('taxl.pca', 'Taxonomy Level', choices = tax.name,
-                                selected='no rank'),
-                 selectInput("select_pca_color", "Color points by:",
-                             covariates),
-                 selectInput("select_pca_shape", "Shape points by:",
-                             covariates.colorbar),
-                 actionButton("DR_plot", "Plot"),
-                 width=3
-             ),
-             mainPanel(
-                 tabsetPanel(
-                     tabPanel("PCA plot",
-                              plotlyOutput("pca.plotly"),
-                              selectInput("select_pca_data_format", "Select data type", c("read count", "log10 CPM", "RA"))),
-                     tabPanel("PCA variance", DT::dataTableOutput("PCAtable")),
-                     tabPanel("PCoA plot",
-                              plotlyOutput("pcoa.plotly"),
-                              selectInput("pcoa.method", "PCoA method:",
-                                          beta.methods)),
-                     tabPanel("PCoA variance", DT::dataTableOutput("PCoAtable"))
-                 )
-             )
-         )
+  sidebarLayout(
+    sidebarPanel(
+      numericInput('xcol.new', 'Principal Component (x-axis)', 1, min = 1, max = 50),
+      numericInput('ycol.new', 'Principal Component (y-axis)', 2, min = 1, max = 50),
+      selectizeInput('taxl.pca', 'Taxonomy Level', choices = tax.name, selected='no rank'),
+      selectInput("select_pca_color", "Color points by:", covariates),
+      selectInput("select_pca_shape", "Shape points by:", covariates.colorbar),
+      actionButton("DR_plot", "Plot"),
+      width=3
+    ),
+    mainPanel(
+      tabsetPanel(
+        tabPanel("PCA",
+          fluidRow(
+            column(9,
+              plotlyOutput("pca.plotly", height="500px"),
+              selectInput("select_pca_data_format", "Select data type", c("read count", "log10 CPM", "RA"))
+            ),
+            column(3,
+              DT::dataTableOutput("PCAtable")
+            )
+          )
+        ),
+        tabPanel("PCoA",
+          fluidRow(
+            column(9,
+              plotlyOutput("pcoa.plotly", height="500px"),
+              selectInput("pcoa.method", "PCoA method:", beta.methods)
+            ),
+            column(3,
+              DT::dataTableOutput("PCoAtable")
+            )
+          )
+        )
+      )
+    )
+  )
 )


### PR DESCRIPTION
- Move plots and tables into columns
- Rename table headers
- Remove table search bar
- Resize plots
- Setting y-axis to 1 effectively allows user to plot only PC1

Fix #37 